### PR TITLE
feat: allow string inputs to eval_teal

### DIFF
--- a/pytealext/evaluator/evaluator.py
+++ b/pytealext/evaluator/evaluator.py
@@ -78,7 +78,7 @@ def split128(val: int):
 
 
 def eval_teal(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-    lines: list[str],
+    lines: list[str] | str,
     return_stack=True,
     context: EvalContext or None = None,
     debug: IO or None = None,
@@ -87,7 +87,7 @@ def eval_teal(  # pylint: disable=too-many-locals,too-many-branches,too-many-sta
     Simulate a basic teal program.
 
     Args:
-        lines: list of TEAL program lines
+        lines: list of TEAL program lines or compiled program string
         return_stack: whenther "return" opcode shall return the whole stack, not just the value on top
             This is useful in validating if custom TEAL code produces correct amount of values on stack.
             Moreover, with pyteal v0.8 every compiled program has a "return" at the end,
@@ -99,6 +99,11 @@ def eval_teal(  # pylint: disable=too-many-locals,too-many-branches,too-many-sta
     Returns:
         tuple of (stack, slots)
     """
+    if isinstance(lines, str):
+        lines = lines.splitlines()
+    if not isinstance(lines, list):
+        raise TypeError("lines must be a list of strings or a string")
+
     stack = []  # type: list[int or str]
     call_stack = []  # type: list[int]
     slots = [0 for _ in range(256)]

--- a/tests/evaluator_test.py
+++ b/tests/evaluator_test.py
@@ -34,7 +34,7 @@ def test_itob_btoi_idempotency(i: int):
     expr = Btoi(Itob(Int(i)))
     expr_asm = compileTeal(expr, Mode.Application, version=VERSION)
 
-    stack, _ = eval_teal(expr_asm.splitlines())
+    stack, _ = eval_teal(expr_asm)
 
     assert len(stack) == 1
     assert stack[0] == i
@@ -47,7 +47,7 @@ def test_btoi(b: bytes):
     expr = Btoi(Bytes(b))
     expr_asm = compileTeal(expr, Mode.Application, version=VERSION)
 
-    stack, _ = eval_teal(expr_asm.splitlines())
+    stack, _ = eval_teal(expr_asm)
 
     assert len(stack) == 1
     assert stack[0] == int.from_bytes(b, "big")
@@ -58,7 +58,7 @@ def test_log():
     expr_asm = compileTeal(expr, Mode.Application, version=VERSION)
 
     ctx = EvalContext()
-    stack, _ = eval_teal(expr_asm.splitlines(), context=ctx)
+    stack, _ = eval_teal(expr_asm, context=ctx)
 
     assert stack == [1]
     assert ctx.log == [b"wubwub", b"numbertwo"]
@@ -201,7 +201,7 @@ def test_exp(i: int, j: int):
     expr = Eq(Exp(i_int, j_int), expected)
     expr_asm = compileTeal(expr, Mode.Application, version=VERSION)
 
-    stack, _ = eval_teal(expr_asm.splitlines())
+    stack, _ = eval_teal(expr_asm)
 
     assert len(stack) == 1
     assert stack[0] == 1
@@ -212,7 +212,7 @@ def test_exp_zero_exponent(base: int):
     expr = Eq(Exp(Int(base), Int(0)), Int(1))
     expr_asm = compileTeal(expr, Mode.Application, version=VERSION)
 
-    stack, _ = eval_teal(expr_asm.splitlines())
+    stack, _ = eval_teal(expr_asm)
 
     assert len(stack) == 1
     assert stack[0] == 1
@@ -226,7 +226,7 @@ def test_exp_fails_for_zeroes():
     expr_asm = compileTeal(expr, Mode.Application, version=VERSION)
 
     with pytest.raises(Panic, match="Invalid input"):
-        eval_teal(expr_asm.splitlines())
+        eval_teal(expr_asm)
 
 
 @given(
@@ -241,7 +241,7 @@ def test_exp_fails_for_overflow(i: int, j: int):
     expr_asm = compileTeal(expr, Mode.Application, version=VERSION)
 
     with pytest.raises(Panic, match="Overflow"):
-        eval_teal(expr_asm.splitlines())
+        eval_teal(expr_asm)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Convenience optional type as an input intended for compatibility with compileTeal